### PR TITLE
Be more thorough when removing whitespace in URLNormalizer

### DIFF
--- a/plone/i18n/normalizer/__init__.py
+++ b/plone/i18n/normalizer/__init__.py
@@ -181,7 +181,7 @@ class URLNormalizer(object):
             base = m.groups()[0]
             ext  = m.groups()[1]
 
-        base = base.replace(' ', '-')
+        base = NON_WORD_REGEX.sub('-', base)
         base = IGNORE_REGEX.sub('', base)
         base = URL_DANGEROUS_CHARS_REGEX.sub('-', base)
         base = EXTRA_DASHES_REGEX.sub('', base)


### PR DESCRIPTION
Before:

```
(Pdb) queryUtility(IURLNormalizer).normalize('a b')
'a-b'
(Pdb) queryUtility(IURLNormalizer).normalize('a\nb')
'a\nb'
```

After:

```
(Pdb) queryUtility(IURLNormalizer).normalize('a b')
'a-b'
(Pdb) queryUtility(IURLNormalizer).normalize('a\nb')
'a-b'
```
