### PR TITLE
Remove leading underscores in urlnormalizer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,15 @@ Changelog
 2.0.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+New:
+
+- *add item here*
+
+Fixes:
+
+- URLNormalizer now removes leading underscores.
+  They are disallowed for content objects in zope.
+  [do3cc]
 
 
 2.0.10 (2015-05-11)

--- a/plone/i18n/normalizer/__init__.py
+++ b/plone/i18n/normalizer/__init__.py
@@ -182,6 +182,11 @@ class URLNormalizer(object):
 
         text = baseNormalize(text)
 
+        # Remove any leading underscores
+        m = UNDERSCORE_START_REGEX.match(text)
+        if m is not None:
+            text = m.groups()[1]
+
         # lowercase text
         base = text.lower()
         ext  = ''

--- a/plone/i18n/normalizer/tests/test_normalizer.py
+++ b/plone/i18n/normalizer/tests/test_normalizer.py
@@ -240,6 +240,11 @@ def testURLNormalizer():
 
       >>> util.normalize(u"short-hello-version", max_length=10)
       'short'
+
+      Leading underscores are forbidden by zope, so this
+      normalizer should strip it
+      >>> util.normalize(u'_awesome.txt')
+      'awesome.txt'
     """
 
 


### PR DESCRIPTION
Leading underscores are forbidden for content objects.
The URLnormalizer is used for defining good names for
content objects