### PR TITLE
Remove backward compatibility for Products.PlacelessTranslationService

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes:
   [pbauer]
 
 
+
+- Remove backward compatibility for Products.PlacelessTranslationService [ksuess]
+
+
 3.0.7 (2017-05-16)
 ------------------
 

--- a/plone/i18n/utility.py
+++ b/plone/i18n/utility.py
@@ -18,12 +18,6 @@ from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.interface import implementer
 
-try:
-    from Products.PlacelessTranslationService.Negotiator import registerLangPrefsMethod  # noqa
-    _hasPTS = 1
-except ImportError:
-    _hasPTS = 0
-
 
 class LanguageBinding(object):
     """Helper which holding language infos in request."""
@@ -479,7 +473,3 @@ class PrefsForPTS(object):
     def getPreferredLanguages(self):
         """Returns the list of the bound languages."""
         return self.languages
-
-
-if _hasPTS:
-    registerLangPrefsMethod({'klass': PrefsForPTS, 'priority': 100})


### PR DESCRIPTION
Last thing  used from PTS was an adapter for IUserPreferredLanguages. It is replaced in zope.publisher.
Related pull requests: plone/Products.CMFPlone#2278 and https://github.com/plone/plone.app.testing/pull/44