### PR TITLE
update to unidecode 1.0.22 and use its features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,10 @@ New features:
 
 Bug fixes:
 
+- Make it work with newwest Unidecode 1.0.22. Use its method instaed of duplicating it in here.
+  Also support newer unicode chars, like with `Bei Jing` in the example.
+  [gogobd, jensens]
+
 - Add Python 2 / 3 compatibility
   [pbauer]
 

--- a/plone/i18n/normalizer/base.py
+++ b/plone/i18n/normalizer/base.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-from unicodedata import decomposition
-from unicodedata import normalize
-
+from unidecode import unidecode
 import six
 import string
 
@@ -9,11 +7,12 @@ import string
 # On OpenBSD string.whitespace has a non-standard implementation
 # See http://dev.plone.org/plone/ticket/4704 for details
 whitespace = ''.join([c for c in string.whitespace if ord(c) < 128])
-allowed = string.ascii_letters + string.digits + string.punctuation + whitespace
-
-CHAR = {}
-NULLMAP = ['' * 0x100]
-UNIDECODE_LIMIT = 0x0530
+allowed = (
+    string.ascii_letters +
+    string.digits +
+    string.punctuation +
+    whitespace
+)
 
 
 def mapUnicode(text, mapping=()):
@@ -36,70 +35,27 @@ def mapUnicode(text, mapping=()):
 
 def baseNormalize(text):
     """
-    This method is used for normalization of unicode characters to the base ASCII
-    letters. Output is ASCII encoded string (or char) with only ASCII letters,
-    digits, punctuation and whitespace characters. Case is preserved.
+    This method is used for normalization of unicode characters to the base
+    ASCII letters. Output is ASCII encoded string (or char) with only ASCII
+    letters, digits, punctuation and whitespace characters. Case is preserved.
 
       >>> baseNormalize(123)
       '123'
 
       >>> baseNormalize(u'a\u0fff')
-      'afff'
+      'a'
 
       >>> baseNormalize(u"foo\N{LATIN CAPITAL LETTER I WITH CARON}")
       'fooI'
 
       >>> baseNormalize(u"\u5317\u4EB0")
-      '53174eb0'
+      'Bei Jing'
     """
     if not isinstance(text, six.string_types):
         # This most surely ends up in something the user does not expect
         # to see. But at least it does not break.
         return repr(text)
 
-    text = text.strip()
-
-    res = []
-    for ch in text:
-        if ch in allowed:
-            # ASCII chars, digits etc. stay untouched
-            res.append(ch)
-        else:
-            ordinal = ord(ch)
-            if ordinal < UNIDECODE_LIMIT:
-                h = ordinal >> 8
-                l = ordinal & 0xff
-
-                c = CHAR.get(h, None)
-
-                if c == None:
-                    try:
-                        mod = __import__('unidecode.x%02x'%(h), [], [], ['data'])
-                    except ImportError:
-                        CHAR[h] = NULLMAP
-                        res.append('')
-                        continue
-
-                    CHAR[h] = mod.data
-
-                    try:
-                        res.append( mod.data[l] )
-                    except IndexError:
-                        res.append('')
-                else:
-                    try:
-                        res.append( c[l] )
-                    except IndexError:
-                        res.append('')
-
-            elif decomposition(ch):
-                normalized = normalize('NFKD', ch).strip()
-                # string may contain non-letter chars too. Remove them
-                # string may result to more than one char
-                res.append(''.join([c for c in normalized if c in allowed]))
-
-            else:
-                # hex string instead of unknown char
-                res.append("%x" % ordinal)
-
-    return ''.join(res).encode('ascii')
+    text = unidecode(text).encode('ascii').strip()
+    text = [c for c in text if c in allowed]
+    return ''.join(text)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Products.CMFPlone',
         'setuptools',
         'six',
-        'Unidecode',
+        'Unidecode>=1.0.22',
         'zope.component',
         'zope.i18n',
         'zope.interface',


### PR DESCRIPTION
Make it work with newwest Unidecode 1.0.22. Use its method instaed of duplicating it in here.
Also support newer unicode chars, like with `Bei Jing` in the example.
needs to run together with https://github.com/plone/buildout.coredev/pull/401