### PR TITLE
Cache the registry lookup in LanguageUtility

### DIFF
--- a/plone/i18n/utility.py
+++ b/plone/i18n/utility.py
@@ -13,6 +13,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import IDublinCore
 from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from ZODB.POSException import ConflictError
+from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component import queryUtility
@@ -84,7 +85,7 @@ class LanguageUtility(object):
         ("css", "js", "kss", "xml", "gif", "jpg", "png", "jpeg")
     )
 
-    @property
+    @lazy_property
     def settings(self):
         registry = getUtility(IRegistry)
         return registry.forInterface(ILanguageSchema, prefix="plone")


### PR DESCRIPTION
This changes the `LanguageUtility.settings` property to a `zope.cachedescriptors.Lazy`.
.settings is called multiple times and shows up in py-spy for restapi calls.
Making this cached on the utility increases req/s on my machine with ~100.

I *do not* know if and what negative side effect might be. Please handle with care.

![Screenshot 2021-02-08 at 23 13 15](https://user-images.githubusercontent.com/70700/107288127-3cd79500-6a63-11eb-86bb-4f1f84c65c6a.png)
