### PR TITLE
Plone 6: Let the sr language be Latin: Sprski.

### DIFF
--- a/news/326.feature
+++ b/news/326.feature
@@ -1,0 +1,4 @@
+Let the sr language be Latin: Sprski.
+If you want to use the Cyrillic character set variant,
+set environment variable `zope_i18n_allowed_languages` to `sr@Cyrl`.
+[maurits]

--- a/plone/i18n/locales/languages.py
+++ b/plone/i18n/locales/languages.py
@@ -464,9 +464,9 @@ _languagelist = {
     "sr": {
         # Note: we support two character sets for this language.
         # See zope_i18n_allowed_languages below.
-        # TODO: in Plone 6.0 native should become 'Srpski',
-        # but that requires copying sr@Latn to sr in plone.app.locales.
-        "native": "српски",
+        # Until and including 5.2, native was Cyrillic: српски.
+        # In Plone 6.0 native became Latin: Srpski.
+        "native": "Srpski",
         "name": "Serbian",
         "flag": "/++resource++country-flags/cs.gif",
     },


### PR DESCRIPTION
Latin is the most used character set in the Serbian language.
If you want to use the Cyrillic character set variant, set environment variable `zope_i18n_allowed_languages` to `sr@Cyrl`.

See https://github.com/collective/plone.app.locales/issues/326