### PR TITLE
Tests: call self.publish with handle_errors=False.

### DIFF
--- a/plone/i18n/tests/test_negotiation.py
+++ b/plone/i18n/tests/test_negotiation.py
@@ -34,6 +34,7 @@ class TestDefaultLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "pt"},
+            handle_errors=False
         )
         self.checkLanguage(response, "en")
 
@@ -55,6 +56,7 @@ class TestNoCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "pt"},
+            handle_errors=False
         )
         self.checkLanguage(response, "pt")
 
@@ -62,6 +64,7 @@ class TestNoCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "de"},
+            handle_errors=False
         )
         self.checkLanguage(response, "de")
 
@@ -70,6 +73,7 @@ class TestNoCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "pt-br"},
+            handle_errors=False
         )
         self.checkLanguage(response, "pt")
 
@@ -92,6 +96,7 @@ class TestCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "pt"},
+            handle_errors=False
         )
         self.checkLanguage(response, "pt")
 
@@ -99,6 +104,7 @@ class TestCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "de"},
+            handle_errors=False
         )
         self.checkLanguage(response, "de")
 
@@ -107,6 +113,7 @@ class TestCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "pt-br"},
+            handle_errors=False
         )
         self.checkLanguage(response, "pt-br")
 
@@ -115,6 +122,7 @@ class TestCombinedLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_ACCEPT_LANGUAGE": "de-de"},
+            handle_errors=False
         )
         self.checkLanguage(response, "de")
 
@@ -137,7 +145,12 @@ class TestContentLanguageNegotiation(LanguageNegotiationTestCase):
         ILanguage(doc).set_language("nl")
         self.assertEqual(doc.Language(), "nl")
         docpath = "/".join(doc.getPhysicalPath())
-        response = self.publish(docpath, self.basic_auth, env={"PATH_INFO": docpath})
+        response = self.publish(
+            docpath,
+            self.basic_auth,
+            env={"PATH_INFO": docpath},
+            handle_errors=False,
+        )
         self.checkLanguage(response, "nl")
 
     def testContentObjectVHMPortal(self):
@@ -155,7 +168,11 @@ class TestContentLanguageNegotiation(LanguageNegotiationTestCase):
         doc.setLanguage("nl")
         self.assertEqual(doc.Language(), "nl")
         docpath = "/".join(self.portal.portal_url.getRelativeContentPath(doc))
-        response = self.publish(vhmBasePath + docpath, self.basic_auth)
+        response = self.publish(
+            vhmBasePath + docpath,
+            self.basic_auth,
+            handle_errors=False
+        )
         self.checkLanguage(response, "nl")
 
     def testContentObjectVHMPortalVHSubpath(self):
@@ -174,7 +191,11 @@ class TestContentLanguageNegotiation(LanguageNegotiationTestCase):
         doc.setLanguage("nl")
         self.assertEqual(doc.Language(), "nl")
         docpath = "/".join(self.portal.portal_url.getRelativeContentPath(doc))
-        response = self.publish(vhmBasePath + docpath, self.basic_auth)
+        response = self.publish(
+            vhmBasePath + docpath,
+            self.basic_auth,
+            handle_errors=False,
+        )
         self.checkLanguage(response, "nl")
 
     def testContentObjectVHMFolder(self):
@@ -196,7 +217,10 @@ class TestContentLanguageNegotiation(LanguageNegotiationTestCase):
         docpath = docpath[len(folder_path) + 1 :]
 
         response = self.publish(
-            vhmBasePath + docpath, self.basic_auth, env={"diazo.off": "1"}
+            vhmBasePath + docpath,
+            self.basic_auth,
+            env={"diazo.off": "1"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "nl")
 
@@ -212,26 +236,38 @@ class TestCcTLDLanguageNegotiation(LanguageNegotiationTestCase):
     def testSimpleHostname(self):
         # For a simple hostname without ccTLD the canonical language is used
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "localhost"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "localhost"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
     def testIPAddress(self):
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "127.0.0.1"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "127.0.0.1"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
     def testDutchDomain(self):
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "plone.nl"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "plone.nl"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "nl")
 
     def testAcceptedLanguages(self):
         # Brazil uses Portugese, which is not in the accepted languages list
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "plone.br"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "plone.br"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
@@ -240,14 +276,20 @@ class TestCcTLDLanguageNegotiation(LanguageNegotiationTestCase):
         # uses both Dutch and French, with a preference for Dutch.
 
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "plone.be"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "plone.be"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "nl")
 
         # If we stop allowing Dutch we should now fall back to French
         self.settings.available_languages = ["en", "fr"]
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "plone.be"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "plone.be"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "fr")
 
@@ -262,13 +304,19 @@ class TestSubdomainLanguageNegotiation(LanguageNegotiationTestCase):
     def testSimpleHostname(self):
         # For a simple hostname without ccTLD the canonical language is used
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "localhost"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "localhost"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
     def testIPAddress(self):
         response = self.publish(
-            self.portal_path, self.basic_auth, env={"HTTP_HOST": "127.0.0.1"}
+            self.portal_path,
+            self.basic_auth,
+            env={"HTTP_HOST": "127.0.0.1"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
@@ -277,6 +325,7 @@ class TestSubdomainLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_HOST": "nl.plone.org"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "nl")
 
@@ -286,6 +335,7 @@ class TestSubdomainLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_HOST": "br.plone.org"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "en")
 
@@ -297,6 +347,7 @@ class TestSubdomainLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_HOST": "be.plone.org"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "nl")
 
@@ -306,5 +357,6 @@ class TestSubdomainLanguageNegotiation(LanguageNegotiationTestCase):
             self.portal_path,
             self.basic_auth,
             env={"HTTP_HOST": "be.plone.org"},
+            handle_errors=False,
         )
         self.checkLanguage(response, "fr")


### PR DESCRIPTION
This gives us a proper error message instead of a status 500.
Then we can see that on ES6 there is a problem finding `icons.tag('arrow-bar-right')`.
I think I have a fix in CMFPlone for that.
Sample exception, if you want the full one:

```
Error in test testAcceptedLanguages (plone.i18n.tests.test_negotiation.TestCcTLDLanguageNegotiation)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/plone-coredev/es6/src/plone.i18n/plone/i18n/tests/test_negotiation.py", line 266, in testAcceptedLanguages
    response = self.publish(
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Testing/ZopeTestCase/functional.py", line 41, in wrapped_func
    return func(*args, **kw)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Testing/ZopeTestCase/functional.py", line 127, in publish
    wsgi_result = publish(env, start_response)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/ZPublisher/WSGIPublisher.py", line 376, in publish_module
    response = _publish(request, new_mod_info)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/ZPublisher/WSGIPublisher.py", line 271, in publish
    result = mapply(obj,
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/ZPublisher/mapply.py", line 85, in mapply
    return debug(object, args, context)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/ZPublisher/WSGIPublisher.py", line 68, in call_object
    return obj(*args)
  File "/Users/maurits/shared-eggs/cp38/zope.browserpage-4.4.0-py3.8.egg/zope/browserpage/simpleviewclass.py", line 41, in __call__
    return self.index(*args, **kw)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 126, in __call__
    return self.__func__(__self__, *args, **kw)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 58, in __call__
    s = self.pt_render(
  File "/Users/maurits/shared-eggs/cp38/zope.pagetemplate-4.6.0-py3.8.egg/zope/pagetemplate/pagetemplate.py", line 133, in pt_render
    return self._v_program(
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/PageTemplates/engine.py", line 365, in __call__
    return template.render(**kwargs)
  File "/Users/maurits/shared-eggs/cp38/z3c.pt-3.3.1-py3.8.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/Users/maurits/community/plone-coredev/es6/var/cache/f8d46c10cfff1026ac9bdab31abe8567.py", line 319, in render
    __m(__stream, econtext.copy(), rcontext, __i18n_domain)
  File "/Users/maurits/community/plone-coredev/es6/var/cache/f910c63ed8645a1ecc0243ffdd2a3528.py", line 688, in render_master
    __cache_4527708048 = _static_4480221776('provider', 'plone.toolbar', econtext=econtext)(_static_4480221584(econtext, __zt_tmp))
  File "/Users/maurits/shared-eggs/cp38/zope.contentprovider-4.2.1-py3.8.egg/zope/contentprovider/tales.py", line 79, in __call__
    return provider.render()
  File "/Users/maurits/community/plone-coredev/es6/src/plone.app.layout/plone/app/layout/viewlets/toolbar.py", line 19, in render
    return self.custom_template()
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 126, in __call__
    return self.__func__(__self__, *args, **kw)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/Five/browser/pagetemplatefile.py", line 58, in __call__
    s = self.pt_render(
  File "/Users/maurits/shared-eggs/cp38/zope.pagetemplate-4.6.0-py3.8.egg/zope/pagetemplate/pagetemplate.py", line 133, in pt_render
    return self._v_program(
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/Products/PageTemplates/engine.py", line 365, in __call__
    return template.render(**kwargs)
  File "/Users/maurits/shared-eggs/cp38/z3c.pt-3.3.1-py3.8.egg/z3c/pt/pagetemplate.py", line 176, in render
    return base_renderer(**context)
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/zpt/template.py", line 302, in render
    return super(PageTemplate, self).render(**_kw)
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/template.py", line 215, in render
    raise_with_traceback(exc, tb)
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/utils.py", line 53, in raise_with_traceback
    raise exc
  File "/Users/maurits/shared-eggs/cp38/Chameleon-3.9.1-py3.8.egg/chameleon/template.py", line 192, in render
    self._render(stream, econtext, rcontext)
  File "/Users/maurits/community/plone-coredev/es6/var/cache/424bb3a8dbef99a970cb59e9340790a7.py", line 224, in render
    __cache_4533863904 = _static_4480221776('python', "icons.tag('arrow-bar-right')", econtext=econtext)(_static_4480221584(econtext, __zt_tmp))
  File "/Users/maurits/shared-eggs/cp38/zope.tales-5.1-py3.8.egg/zope/tales/pythonexpr.py", line 73, in __call__
    return eval(self._code, vars)
   - __traceback_info__: (icons.tag('arrow-bar-right'))
  File "<string>", line 1, in <module>
  File "/Users/maurits/community/plone-coredev/es6/src/Products.CMFPlone/Products/CMFPlone/browser/icons.py", line 113, in tag
    iconfile = self._iconfile(icon)
  File "/Users/maurits/community/plone-coredev/es6/src/Products.CMFPlone/Products/CMFPlone/browser/icons.py", line 82, in _iconfile
    return site.restrictedTraverse(icon)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/OFS/Traversable.py", line 364, in restrictedTraverse
    return self.unrestrictedTraverse(path, default, restricted=True)
  File "/Users/maurits/community/plone-coredev/es6/src/Zope/src/OFS/Traversable.py", line 236, in unrestrictedTraverse
    next = namespaceLookup(
   - __traceback_info__: (['arrow-bar-right.svg'], '++plone++bootstrap-icons')
  File "/Users/maurits/shared-eggs/cp38/zope.traversing-4.4.1-py3.8.egg/zope/traversing/namespace.py", line 165, in namespaceLookup
    return traverser.traverse(name, ())
  File "/Users/maurits/community/plone-coredev/es6/src/Products.CMFPlone/Products/CMFPlone/traversal.py", line 36, in traverse
    resource_name, resource_filepath = resource_path.split('/', 1)
ValueError: not enough values to unpack (expected 2, got 1)

 - Expression: "python:icons.tag('arrow-bar-right')"
 - Filename:   ... rc/plone.app.layout/plone/app/layout/viewlets/toolbar.pt
 - Location:   (line 13: col 39)
 - Source:     ... lace="structure python:icons.tag('arrow-bar-right')" />
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "provider:plone.toolbar"
 - Filename:   ... one/Products/CMFPlone/browser/templates/main_template.pt
 - Location:   (line 55: col 32)
 - Source:     ... al:replace="structure provider:plone.toolbar" />
                                         ^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "context/@@main_template/macros/master"
 - Filename:   ... pes/plone/app/contenttypes/browser/templates/document.pt
 - Location:   (line 6: col 21)
 - Source:     ... tal:use-macro="context/@@main_template/macros/master"
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  template: <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x10e0a4fd0>
               options: {}
               args: ()
               nothing: None
               modules: <Products.PageTemplates.ZRPythonExpr._SecureModuleImporter object at 0x10a559e80>
               request: <WSGIRequest, URL=None>
               view: <Products.Five.viewlet.manager.<ViewletManager providing IToolbar> object at 0x11016a8e0>
               context: <PloneSite at /plone>
               views: <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x110178910>
               here: <PloneSite at /plone>
               container: <PloneSite at /plone>
               root: <Application at >
               traverse_subpath: []
               user: <PloneUser 'test-user'>
               default: <DEFAULT>
               repeat: <Products.PageTemplates.engine.RepeatDictWrapper object at 0x10d7793c0>
               loop: {}
               target_language: None
               translate: <function BaseTemplate.render.<locals>.translate at 0x110168c10>
               attrs: {}
               context_state: <Products.Five.browser.metaconfigure.ContextState object at 0x110178550>
               icons: <Products.Five.browser.metaconfigure.IconsView object at 0x1101871c0>
               personal_bar: <plone.app.layout.viewlets.common.PersonalBarViewlet object at 0x110187280>
```

I call this branch `es6`, but it is fine for standard coredev.