### PR TITLE
Added native names for German and Dutch language variants

### DIFF
--- a/news/824.bugfix
+++ b/news/824.bugfix
@@ -1,0 +1,3 @@
+Added native names for German and Dutch country-specific language variants.
+Then all related language variants are shown together in the language control panel.
+[maurits]

--- a/plone/i18n/locales/languages.py
+++ b/plone/i18n/locales/languages.py
@@ -713,26 +713,32 @@ _combinedlanguagelist = {
     },
     "de-be": {
         "name": "German (Belgium)",
+        "native": "Deutsch (Belgien)",
         "flag": "countryflag/de",
     },
     "de-ch": {
         "name": "German (Switzerland)",
+        "native": "Deutsch (Schweiz)",
         "flag": "countryflag/ch",
     },
     "de-de": {
         "name": "German (Germany)",
+        "native": "Deutsch (Deutschland)",
         "flag": "countryflag/de",
     },
     "de-dk": {
         "name": "German (Denmark)",
+        "native": "Deutsch (Danmark)",
         "flag": "countryflag/de",
     },
     "de-li": {
         "name": "German (Liechtenstein)",
+        "native": "Deutsch (Liechtenstein)",
         "flag": "countryflag/li",
     },
     "de-lu": {
         "name": "German (Luxembourg)",
+        "native": "Deutsch (Luxemburg)",
         "flag": "countryflag/de",
     },
     "el-cy": {
@@ -1357,22 +1363,27 @@ _combinedlanguagelist = {
     },
     "nl-an": {
         "name": "Dutch (Netherlands Antilles)",
+        "native": "Nederlands (Antillen)",
         "flag": "countryflag/an",
     },
     "nl-aw": {
         "name": "Dutch (Aruba)",
+        "native": "Nederlands (Aruba)",
         "flag": "countryflag/aw",
     },
     "nl-be": {
         "name": "Dutch (Belgium)",
+        "native": "Nederlands (België)",
         "flag": "countryflag/be",
     },
     "nl-nl": {
         "name": "Dutch (Netherlands)",
+        "native": "Nederlands (Nederland)",
         "flag": "countryflag/nl",
     },
     "nl-sr": {
         "name": "Dutch (Suriname)",
+        "native": "Nederlands (Suriname)",
         "flag": "countryflag/sr",
     },
     "pt-ao": {


### PR DESCRIPTION
Then all related language variants are shown together in the language control panel.
Fixes https://github.com/plone/Products.CMFPlone/issues/824, at least for these two languages.

BTW, it can be tricky to decide how to call this. For `nl-be` (Dutch spoken in Belgium) I called it "Nederlands (België)", which is the format that we use for most native languages in this dictionary. Native speakers would really call it "Vlaams" (Flemish). But then it would not be shown together with the other Dutch variants, so I suppose the way I have it now is good.

@agitator Please check my German spelling. :-)