### PR TITLE
Optimize performance of the language utility

### DIFF
--- a/news/47.bugfix
+++ b/news/47.bugfix
@@ -1,0 +1,1 @@
+- Optimize performance of language negotiation. [davisagli]

--- a/plone/i18n/utility.py
+++ b/plone/i18n/utility.py
@@ -12,6 +12,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import IDublinCore
 from Products.SiteAccess.VirtualHostMonster import VirtualHostMonster
 from ZODB.POSException import ConflictError
+from zope.cachedescriptors.property import Lazy as lazy_property
 from zope.component import getMultiAdapter
 from zope.component import getUtility
 from zope.component.hooks import getSite
@@ -79,7 +80,7 @@ class LanguageUtility:
 
     exclude_exts = frozenset(("css", "js", "kss", "xml", "gif", "jpg", "png", "jpeg"))
 
-    @property
+    @lazy_property
     def settings(self):
         registry = getUtility(IRegistry)
         return registry.forInterface(ILanguageSchema, prefix="plone")


### PR DESCRIPTION
Language negotiation uses the `settings` property of the language utility a lot. Each time it constructs a new copy of the language settings, so let's memoize it. This isn't a huge amount of clock time (< 1ms) but it was enough to show up in some profiling I was doing, and it's easy to make it 6.6 times faster by doing this (0.99ms -> 0.15ms on my laptop).